### PR TITLE
feat: integrate friend request socket events

### DIFF
--- a/app/(main)/(tabs)/friends/index.tsx
+++ b/app/(main)/(tabs)/friends/index.tsx
@@ -1,13 +1,115 @@
-import { View } from '@/components/ui/view'
-import { Text } from '@/components/ui/text'
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react';
+import { FlatList } from 'react-native';
+import { View } from '@/components/ui/view';
+import { Text } from '@/components/ui/text';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toast';
+import apiService from '@/lib/api';
+import { useSocket } from '@/contexts/SocketContext';
 
-const FriendsScreen = () => {
-  return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>FriendsScreen</Text>
-    </View>
-  )
+interface FriendRequest {
+  id: string;
+  user_id: string;
+  username: string;
+  display_name: string;
+  avatar_url: string | null;
+  created_at: string;
 }
 
-export default FriendsScreen
+const FriendsScreen = () => {
+  const [requests, setRequests] = useState<FriendRequest[]>([]);
+  const {
+    onFriendRequest,
+    onFriendRequestAccepted,
+    onFriendRequestRejected,
+    onFriendRemoved,
+    onFriendBlocked,
+    isConnected,
+  } = useSocket();
+  const toast = useToast();
+
+  const fetchRequests = useCallback(async () => {
+    try {
+      const data = await apiService.getFriendRequests();
+      setRequests(data.incoming || []);
+    } catch (error) {
+      console.error('Failed to load friend requests', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  useEffect(() => {
+    const offRequest = onFriendRequest((data) => {
+      toast.info('New friend request', `${data.display_name} sent you a request`);
+      setRequests((prev) => [data, ...prev]);
+    });
+    const offAccepted = onFriendRequestAccepted((data) =>
+      toast.success('Request accepted', `${data.display_name} accepted your request`)
+    );
+    const offRejected = onFriendRequestRejected((data) =>
+      toast.info('Request rejected', `${data.display_name} rejected your request`)
+    );
+    const offRemoved = onFriendRemoved((data) =>
+      toast.info('Friend removed', `${data.display_name} removed you`)
+    );
+    const offBlocked = onFriendBlocked((data) =>
+      toast.error('Blocked', `${data.display_name} blocked you`)
+    );
+    return () => {
+      offRequest();
+      offAccepted();
+      offRejected();
+      offRemoved();
+      offBlocked();
+    };
+  }, [onFriendRequest, onFriendRequestAccepted, onFriendRequestRejected, onFriendRemoved, onFriendBlocked, toast]);
+
+  const handleAccept = async (id: string) => {
+    try {
+      await apiService.acceptFriendRequest(id);
+      setRequests((prev) => prev.filter((r) => r.id !== id));
+    } catch (error) {
+      console.error('Accept failed', error);
+    }
+  };
+
+  const handleReject = async (id: string) => {
+    try {
+      await apiService.rejectFriendRequest(id);
+      setRequests((prev) => prev.filter((r) => r.id !== id));
+    } catch (error) {
+      console.error('Reject failed', error);
+    }
+  };
+
+  const renderItem = ({ item }: { item: FriendRequest }) => (
+    <View className="flex-row items-center justify-between px-4 py-2 border-b border-gray-200">
+      <Text className="font-medium">{item.display_name || item.username}</Text>
+      <View className="flex-row space-x-2">
+        <Button size="sm" label="Accept" onPress={() => handleAccept(item.id)} />
+        <Button size="sm" variant="outline" label="Reject" onPress={() => handleReject(item.id)} />
+      </View>
+    </View>
+  );
+
+  return (
+    <View className="flex-1">
+      <View className="p-4">
+        <Text className="text-base font-semibold">
+          Connection: {isConnected ? 'online' : 'offline'}
+        </Text>
+      </View>
+      <FlatList
+        data={requests}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListEmptyComponent={<Text className="text-center mt-4">No pending requests</Text>}
+      />
+    </View>
+  );
+};
+
+export default FriendsScreen;

--- a/contexts/SocketContext.tsx
+++ b/contexts/SocketContext.tsx
@@ -2,7 +2,6 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 import { io, Socket } from 'socket.io-client';
-import { Alert } from 'react-native';
 
 type FriendRequest = {
   id: string;
@@ -28,6 +27,7 @@ type SocketContextType = {
   onFriendRequestAccepted: (callback: (data: FriendEvent) => void) => () => void;
   onFriendRequestRejected: (callback: (data: FriendEvent) => void) => () => void;
   onFriendRemoved: (callback: (data: FriendEvent) => void) => () => void;
+  onFriendBlocked: (callback: (data: FriendEvent) => void) => () => void;
 };
 
 const SocketContext = createContext<SocketContextType>({
@@ -37,6 +37,7 @@ const SocketContext = createContext<SocketContextType>({
   onFriendRequestAccepted: () => () => {},
   onFriendRequestRejected: () => () => {},
   onFriendRemoved: () => () => {},
+  onFriendBlocked: () => () => {},
 });
 
 const SOCKET_URL = 'http://192.168.1.233:5001'; // Change to your backend IP
@@ -69,9 +70,16 @@ export const SocketProvider = ({ token, children }: { token: string; children: R
   
   const onFriendRemoved = useCallback((callback: (data: FriendEvent) => void) => {
     if (!socket) return () => {};
-    
+
     socket.on('friend_removed', callback);
     return () => socket.off('friend_removed', callback);
+  }, [socket]);
+
+  const onFriendBlocked = useCallback((callback: (data: FriendEvent) => void) => {
+    if (!socket) return () => {};
+
+    socket.on('friend_blocked', callback);
+    return () => socket.off('friend_blocked', callback);
   }, [socket]);
 
   // Connect socket on mount
@@ -123,7 +131,8 @@ export const SocketProvider = ({ token, children }: { token: string; children: R
       onFriendRequest,
       onFriendRequestAccepted,
       onFriendRequestRejected,
-      onFriendRemoved
+      onFriendRemoved,
+      onFriendBlocked
     }}>
       {children}
     </SocketContext.Provider>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,3 @@
-import * as SecureStore from "expo-secure-store";
 import axios from "axios";
 import { API_URL } from "../constants";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -315,6 +314,135 @@ class ApiService {
       );
     } catch (error) {
       console.error('Failed to record story view:', error);
+      throw error;
+    }
+  }
+
+  // ---------------------------FRIEND ROUTES---------------------------
+  async getFriends() {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.get('api/friends', undefined, auth_token);
+    } catch (error) {
+      console.error('Failed to fetch friends:', error);
+      throw error;
+    }
+  }
+
+  async getFriendRequests() {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.get('api/friends/requests', undefined, auth_token);
+    } catch (error) {
+      console.error('Failed to fetch friend requests:', error);
+      throw error;
+    }
+  }
+
+  async sendFriendRequest(receiverId: string) {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.post(
+        'api/friends/request',
+        { receiverId },
+        auth_token,
+        undefined,
+        { 'Content-Type': 'application/json' }
+      );
+    } catch (error) {
+      console.error('Failed to send friend request:', error);
+      throw error;
+    }
+  }
+
+  async acceptFriendRequest(requestId: string) {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.post(
+        `api/friends/request/${requestId}/accept`,
+        {},
+        auth_token,
+        undefined,
+        { 'Content-Type': 'application/json' }
+      );
+    } catch (error) {
+      console.error('Failed to accept friend request:', error);
+      throw error;
+    }
+  }
+
+  async rejectFriendRequest(requestId: string) {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.post(
+        `api/friends/request/${requestId}/reject`,
+        {},
+        auth_token,
+        undefined,
+        { 'Content-Type': 'application/json' }
+      );
+    } catch (error) {
+      console.error('Failed to reject friend request:', error);
+      throw error;
+    }
+  }
+
+  async removeFriend(friendshipId: string) {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.delete(`api/friends/${friendshipId}`, auth_token);
+    } catch (error) {
+      console.error('Failed to remove friend:', error);
+      throw error;
+    }
+  }
+
+  async blockFriend(friendshipId: string) {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.post(
+        `api/friends/${friendshipId}/block`,
+        {},
+        auth_token,
+        undefined,
+        { 'Content-Type': 'application/json' }
+      );
+    } catch (error) {
+      console.error('Failed to block friend:', error);
+      throw error;
+    }
+  }
+
+  async checkFriendshipStatus(otherUserId: string) {
+    try {
+      const auth_token = await AsyncStorage.getItem('auth_token');
+      if (!auth_token) {
+        throw new Error('No auth token found');
+      }
+      return this.api.get(`api/friends/status/${otherUserId}`, undefined, auth_token);
+    } catch (error) {
+      console.error('Failed to check friendship status:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- extend socket context with friend blocked events
- add API helpers for friends and friend requests
- build friend requests screen with socket-driven updates

## Testing
- `npm run lint` *(fails: Component definition is missing display name)*
- `npx eslint app/(main)/(tabs)/friends/index.tsx contexts/SocketContext.tsx lib/api.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a731f89f18832b90891286f361c406